### PR TITLE
@mentions with github-credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,71 @@ Then add **hubot-github-pr-reporter** to your `external-scripts.json`:
 * "moment": "2.10.6"        - Used for report formatting
 * "node-schedule": "0.5.1"  - Used for the scheduling feature
 * "underscore": "1.8.3"     - Used for report formatting
-* "github-credentials"      - Optional. Translates github names to @mention names. 
+* "github-credentials"      - Optional. Translates github names to @mention names.
 
 ## Sample Interaction
 
+### Show a list of open pull requests
 ```
-user1>> hubot hello
-hubot>> hello!
+gary> hubot show prs
+hubot>
+@gary:
+  8 hours, 0 comments, @dala, Improve reporting
+  ↳ https://github.com/example/reporting/pull/42
+  3 hours, 2 comments, *unassigned*, Updated readme
+  ↳ https://github.com/example/reporting/pull/24
+mr_house:
+  *6 months*, 0 comments, benny, Updates to platinum chip
+  ↳ https://github.com/example/chip/pull/101
 ```
+
+You can specify:
+* No options. Just `hubot show prs` to get the fire hose.
+* A user to show PRs by that author, by adding a `user:githubLogin` string
+* A team to show PRs authored by that team, by adding a `team:teamName` string
+* An organization to show all open PRs in that org, by adding a `org:organizationName` string
+
+Note that the order matters, and they chain when possible. For instance:
+* Specifying user and org limit the responses to just that user in that org. Useful if a user has open PRs in multiple orgs, but you only care about one.
+* Specifying a team and an org helps specify which team you mean, since team names aren't globally unique.
+
+### Subscribe to PR reports
+```
+gary> hubot subscribe prs for user:mr_house
+hubot> @gary: Great! This request will show you all PRs mentioning mr_house at the default frequency (weekdays at noon)
+
+... then, at noon ...
+hubot>
+mr_house:
+  *6 months*, 0 comments, benny, Updates to platinum chip
+  ↳ https://github.com/example/chip/pull/101
+
+To unsubscribe, type `hubot unsubscribe prs 5`
+```
+You can specify:
+* The same options for name, team, and org above. Same rules apply.
+* A custom frequency by specifying the cron format you want hubot to report at. You can do this by adding `cron:"your cron string"` to the command.
+
+### Show a list of all ongoing subscriptions
+```
+gary> hubot show pr subscriptions
+hubot>
+ID   Requestor    Description
+5    gary         paused => org:example
+```
+This will show all of the subscriptions for the room you're currently in. To see all subscriptions hubot is keeping track of, add 'all' to the request:
+```
+gary> hubot show all pr subscriptions
+hubot>
+Room           ID   Requestor    Description
+engineering    5    gary         org:example
+research       7    mr_house     paused => team:securitron org:example
+```
+A "paused" mention in the description just means hubot lost a reference to the room, and can't post to it until someone says something. As soon as there's other activity in the room, it'll automatically resume the subscription.
+
+### Unsubscribe from a report
+```
+gary> hubot unsubscribe pr 5
+hubot> Successfully unsubscribed from 5: all PRs in the example organization at the default frequency (weekdays at noon)
+```
+Note that you need to be in the room that requested the subscription in order to unsubscribe. That's so folks in that room know that the subscription was stopped, rather than something broke.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Then add **hubot-github-pr-reporter** to your `external-scripts.json`:
 * "moment": "2.10.6"        - Used for report formatting
 * "node-schedule": "0.5.1"  - Used for the scheduling feature
 * "underscore": "1.8.3"     - Used for report formatting
+* "github-credentials"      - Optional. Translates github names to @mention names. 
 
 ## Sample Interaction
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ mr_house:
 
 You can specify:
 * No options. Just `hubot show prs` to get the fire hose.
-* A user to show PRs by that author, by adding a `user:githubLogin` string
+* A user to show PRs by that author, by adding a `user:githubLogin` string. If you're using github-credentials, you can also specify the user by the chat room name (like `user:@chatName`), and hubot will automatically translate it to their github name.
 * A team to show PRs authored by that team, by adding a `team:teamName` string
 * An organization to show all open PRs in that org, by adding a `org:organizationName` string
 

--- a/src/github-pr-reporter.coffee
+++ b/src/github-pr-reporter.coffee
@@ -11,6 +11,7 @@
 #    "moment": "2.10.6"        - Used for report formatting
 #    "node-schedule": "0.5.1"  - Used for the scheduling feature
 #    "underscore": "1.8.3"     - Used for report formatting
+#    "github-credentials"      - Optional. Translates github names to @mention names
 #
 # Commands:
 #   hubot show prs for [user:user] [team:team] [org:organization] - List PRs by author, filter by user, team, or organization. If nothing is specified, it will be for all orgs that hubot can access.

--- a/src/github-pr-reporter.coffee
+++ b/src/github-pr-reporter.coffee
@@ -265,7 +265,7 @@ refreshCachedGithubData = (github) ->
 # Main methods. These map almost 1:1 with the registered responders below.
 #
 
-parseDigestRequest = (github, userName, teamName, organizationName, callback) ->
+parseDigestRequest = (robot, github, userName, teamName, organizationName, callback) ->
   # These regexes are really permissive.
   # If they specify 2 things, then it's user, then organization. Validate both.
   # If they specify nothing, then we've got nothing to give.
@@ -393,7 +393,7 @@ module.exports = (robot) ->
 
   robot.respond /show prs?(?: for)?(?: user:([\w\-]+))?(?: team:([\w_\-.]+))?(?: org:([\w\-]+))?$/i, (res) ->
     [ignored, user, team, org] = res.match
-    parseDigestRequest github, user, team, org, (digestRequest, error) ->
+    parseDigestRequest robot, github, user, team, org, (digestRequest, error) ->
       if error?
         res.send "`#{res.match[0]}` failed: #{error}"
       else
@@ -403,7 +403,7 @@ module.exports = (robot) ->
 
   robot.respond /sub(?:scribe)? prs?(?: for)?(?: user:([\w\-]+))?(?: team:([\w_\-.]*))?(?: org:([\w\-]))?(?: cron:[“"”](.*)[“"”])?/i, (res) ->
     [ignored, user, team, org, cron] = res.match
-    parseDigestRequest github, user, team, org, (digestRequest, error) ->
+    parseDigestRequest robot, github, user, team, org, (digestRequest, error) ->
       unless error?
         if cron?
           try

--- a/src/github-pr-reporter.coffee
+++ b/src/github-pr-reporter.coffee
@@ -180,12 +180,17 @@ digestForRequest = (robot, github, digestRequest, callback) ->
         return userMap
       , {}
     )
+    familiarName = (githubLogin) ->
+      if githubLogin? and githubToNameMap[githubLogin]
+        return "@#{githubToNameMap[githubLogin]}"
+      else
+        return githubLogin
     _.forEach groupedIssues, (issues, login) ->
-      digest += "#{login}:\n"
+      digest += "#{familiarName(login)}:\n"
       issues.forEach (issue) ->
         age = ageOfIssue issue
         comments = "#{issue.comments} comments"
-        assignee = issue.assignee?.login or "*unassigned*"
+        assignee = familiarName(issue.assignee?.login) or "*unassigned*"
         title = issue.title
         link = issue.html_url
 

--- a/src/github-pr-reporter.coffee
+++ b/src/github-pr-reporter.coffee
@@ -120,7 +120,7 @@ ageOfIssue = (issue) ->
   else
     duration.humanize()
 
-digestForRequest = (github, digestRequest, callback) ->
+digestForRequest = (robot, github, digestRequest, callback) ->
   # Fetch all issues, either for the single org on the request or for all orgs
   orgNameList = organizations.map (org) -> org.login
   if digestRequest.organizationName?
@@ -173,6 +173,7 @@ digestForRequest = (github, digestRequest, callback) ->
     groupedIssues = _.groupBy sortedIssues, (issue) ->
       issue.user.login
     _.forEach groupedIssues, (issues, login) ->
+
       digest += "#{login}:\n"
       issues.forEach (issue) ->
         age = ageOfIssue issue
@@ -227,7 +228,7 @@ resubscribeRoom = (robot, github, room, res) ->
       if request.room == room
         frequency = request.scheduleFrequency or DEFAULT_SCHEDULE_FREQUENCY
         request.scheduledJob = schedule.scheduleJob frequency, () ->
-          digestForRequest github, request, (digest) ->
+          digestForRequest robot, github, request, (digest) ->
             if res?
               res.send "#{digest}\n\nTo unsubscribe, type `#{robot.name} unsubscribe prs #{request.id}`\n"
       else
@@ -352,7 +353,7 @@ scheduleDigest = (robot, github, res, request, callback) ->
     frequency = request.scheduleFrequency or DEFAULT_SCHEDULE_FREQUENCY
     subscribedRooms.push request.room
     request.scheduledJob = schedule.scheduleJob frequency, () ->
-      digestForRequest github, request, (digest) ->
+      digestForRequest robot, github, request, (digest) ->
         if res?
           res.send "#{digest}\n\nTo unsubscribe, type `#{robot.name} unsubscribe prs #{request.id}`\n"
   catch error
@@ -381,7 +382,7 @@ module.exports = (robot) ->
         res.send "`#{res.match[0]}` failed: #{error}"
       else
         digestRequest.id = getNextId robot
-        digestForRequest github, digestRequest, (digest) ->
+        digestForRequest robot, github, digestRequest, (digest) ->
           res.send digest
 
   robot.respond /sub(?:scribe)? prs?(?: for)?(?: user:([\w\-]+))?(?: team:([\w_\-.]*))?(?: org:([\w\-]))?(?: cron:[“"”](.*)[“"”])?/i, (res) ->

--- a/src/github-pr-reporter.coffee
+++ b/src/github-pr-reporter.coffee
@@ -125,8 +125,8 @@ getLatestNameMap = (robot) ->
   return _.reduce(
     robot.brain.users(),
     (userMap, user) ->
-      if user.githubLogin
-        userMap[user.githubLogin] = user.name
+      if user.githubLogin?
+        userMap[user.githubLogin.toLowerCase()] = user.name.toLowerCase()
       return userMap
     , {}
   )
@@ -185,8 +185,8 @@ digestForRequest = (robot, github, digestRequest, callback) ->
       issue.user.login
     githubToNameMap = getLatestNameMap(robot)
     familiarName = (githubLogin) ->
-      if githubLogin? and githubToNameMap[githubLogin]
-        return "@#{githubToNameMap[githubLogin]}"
+      if githubLogin? and githubToNameMap[githubLogin.toLowerCase()]
+        return "@#{githubToNameMap[githubLogin.toLowerCase()]}"
       else
         return githubLogin
     _.forEach groupedIssues, (issues, login) ->
@@ -311,6 +311,7 @@ You may need to invite hubot to the #{teamName} team for it to be queryable."
 
   if userName?
     userPromise = new Promise (resolve, reject) ->
+      userName = userName.toLowerCase()
 
       # Translate from @roomName to github userName if needed
       if userName.length > 1 && userName[0] == "@"
@@ -322,7 +323,6 @@ You may need to invite hubot to the #{teamName} team for it to be queryable."
           reject "I don't know who #{userName} is. Ask #{userName} to tell me their github login. " +
             "Type `#{robot.name} who do you know?` to see everyone I know github logins for."
           return
-      userName = userName.toLowerCase()
 
       # if we have a valid team, then ask for all the members of that team.
       # if we have a valid org, then ask for all the members of that org

--- a/src/github-pr-reporter.coffee
+++ b/src/github-pr-reporter.coffee
@@ -172,8 +172,15 @@ digestForRequest = (robot, github, digestRequest, callback) ->
       moment(issue.updated_at)
     groupedIssues = _.groupBy sortedIssues, (issue) ->
       issue.user.login
+    githubToNameMap = _.reduce(
+      robot.brain.users(),
+      (userMap, user) ->
+        if user.githubLogin
+          userMap[user.githubLogin] = user.name
+        return userMap
+      , {}
+    )
     _.forEach groupedIssues, (issues, login) ->
-
       digest += "#{login}:\n"
       issues.forEach (issue) ->
         age = ageOfIssue issue

--- a/src/github-pr-reporter.coffee
+++ b/src/github-pr-reporter.coffee
@@ -310,6 +310,15 @@ You may need to invite hubot to the #{teamName} team for it to be queryable."
 
 
   if userName?
+    # Translate from @roomName to github userName if needed
+    if userName.length > 1 && userName[0] == "@"
+      nameToGithubMap = _.invert(getLatestNameMap(robot))
+      chatName = userName[1...]
+      if nameToGithubMap[chatName]?
+        userName = nameToGithubMap[chatName]
+      else
+        error or= "I don't know who #{userName} is. Ask #{userName} to tell me their github login."
+        userPromise = Promise.resolve null
     userPromise = new Promise (resolve, reject) ->
       userName = userName.toLowerCase()
 
@@ -391,7 +400,7 @@ module.exports = (robot) ->
   robot.brain.once "loaded", () ->
     getSubscriptions robot
 
-  robot.respond /show prs?(?: for)?(?: user:([\w\-]+))?(?: team:([\w_\-.]+))?(?: org:([\w\-]+))?$/i, (res) ->
+  robot.respond /show prs?(?: for)?(?: user:(@?[\w\-]+))?(?: team:([\w_\-.]+))?(?: org:([\w\-]+))?$/i, (res) ->
     [ignored, user, team, org] = res.match
     parseDigestRequest robot, github, user, team, org, (digestRequest, error) ->
       if error?
@@ -401,7 +410,7 @@ module.exports = (robot) ->
         digestForRequest robot, github, digestRequest, (digest) ->
           res.send digest
 
-  robot.respond /sub(?:scribe)? prs?(?: for)?(?: user:([\w\-]+))?(?: team:([\w_\-.]*))?(?: org:([\w\-]))?(?: cron:[“"”](.*)[“"”])?/i, (res) ->
+  robot.respond /sub(?:scribe)? prs?(?: for)?(?: user:(@?[\w\-]+))?(?: team:([\w_\-.]*))?(?: org:([\w\-]))?(?: cron:[“"”](.*)[“"”])?/i, (res) ->
     [ignored, user, team, org, cron] = res.match
     parseDigestRequest robot, github, user, team, org, (digestRequest, error) ->
       unless error?

--- a/src/github-pr-reporter.coffee
+++ b/src/github-pr-reporter.coffee
@@ -121,6 +121,16 @@ ageOfIssue = (issue) ->
   else
     duration.humanize()
 
+getLatestNameMap = (robot) ->
+  return _.reduce(
+    robot.brain.users(),
+    (userMap, user) ->
+      if user.githubLogin
+        userMap[user.githubLogin] = user.name
+      return userMap
+    , {}
+  )
+
 digestForRequest = (robot, github, digestRequest, callback) ->
   # Fetch all issues, either for the single org on the request or for all orgs
   orgNameList = organizations.map (org) -> org.login
@@ -173,14 +183,7 @@ digestForRequest = (robot, github, digestRequest, callback) ->
       moment(issue.updated_at)
     groupedIssues = _.groupBy sortedIssues, (issue) ->
       issue.user.login
-    githubToNameMap = _.reduce(
-      robot.brain.users(),
-      (userMap, user) ->
-        if user.githubLogin
-          userMap[user.githubLogin] = user.name
-        return userMap
-      , {}
-    )
+    githubToNameMap = getLatestNameMap(robot)
     familiarName = (githubLogin) ->
       if githubLogin? and githubToNameMap[githubLogin]
         return "@#{githubToNameMap[githubLogin]}"

--- a/src/github-pr-reporter.coffee
+++ b/src/github-pr-reporter.coffee
@@ -310,16 +310,18 @@ You may need to invite hubot to the #{teamName} team for it to be queryable."
 
 
   if userName?
-    # Translate from @roomName to github userName if needed
-    if userName.length > 1 && userName[0] == "@"
-      nameToGithubMap = _.invert(getLatestNameMap(robot))
-      chatName = userName[1...]
-      if nameToGithubMap[chatName]?
-        userName = nameToGithubMap[chatName]
-      else
-        error or= "I don't know who #{userName} is. Ask #{userName} to tell me their github login."
-        userPromise = Promise.resolve null
     userPromise = new Promise (resolve, reject) ->
+
+      # Translate from @roomName to github userName if needed
+      if userName.length > 1 && userName[0] == "@"
+        nameToGithubMap = _.invert(getLatestNameMap(robot))
+        chatName = userName[1...]
+        if nameToGithubMap[chatName]?
+          userName = nameToGithubMap[chatName]
+        else
+          reject "I don't know who #{userName} is. Ask #{userName} to tell me their github login. " +
+            "Type `#{robot.name} who do you know?` to see everyone I know github logins for."
+          return
       userName = userName.toLowerCase()
 
       # if we have a valid team, then ask for all the members of that team.


### PR DESCRIPTION
Everywhere you used to have to mention someone by github login, you can now mention them by chat name. As long as they've told hubot who they are on github (`hubot i am downie`) then it'll remember and make that mapping on all requests.

Also, adds clear documentation to the README for existing + additional functionality.

/cc: @theazureshadow @kimdhamilton 